### PR TITLE
Feature/81 audio manager - suggested improvements

### DIFF
--- a/Assets/Prefabs/Managers/AudioManager.prefab
+++ b/Assets/Prefabs/Managers/AudioManager.prefab
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9118620774135255154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1688957944187613203}
+  - component: {fileID: -4490934623925820354}
+  m_Layer: 0
+  m_Name: AudioManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1688957944187613203
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9118620774135255154}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-4490934623925820354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9118620774135255154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c84fa8100670d3409ceb4d72973100b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sounds: []
+  musics:
+  - name: 0
+    clip: {fileID: 8300000, guid: 6cc38bc79fca2af4f8d6ff752c6b0db3, type: 3}
+    volume: 1
+  - name: 1
+    clip: {fileID: 8300000, guid: dc200328575fdec4fa1280c01757cc07, type: 3}
+    volume: 1

--- a/Assets/Prefabs/Managers/AudioManager.prefab.meta
+++ b/Assets/Prefabs/Managers/AudioManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Managers/LevelManager.prefab
+++ b/Assets/Prefabs/Managers/LevelManager.prefab
@@ -123,6 +123,36 @@ MonoBehaviour:
   loadImage: {fileID: 1792871598366607946}
   maxDelayIn: 0.5
   maxDelayOut: 0.5
+  levelChange:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: -4490934623925820354, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+        m_TargetAssemblyTypeName: AudioManager, Assembly-CSharp
+        m_MethodName: ChangeMusicOnLevelChange
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  gameStart:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: -4490934623925820354, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+        m_TargetAssemblyTypeName: AudioManager, Assembly-CSharp
+        m_MethodName: PlayMusicOnGameStart
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8915063096993590938
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main Menu.unity
+++ b/Assets/Scenes/Main Menu.unity
@@ -266,6 +266,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 654591993}
   m_CullTransparentMesh: 1
+--- !u!1001 &686957628
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1688957944187613203, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9118620774135255154, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
+      propertyPath: m_Name
+      value: AudioManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6f99c8e0d1d8f8a40b6da3fa2e81875e, type: 3}
 --- !u!1001 &751385222
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -559,11 +616,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 5153153598828555895, guid: d03eae8b57c5f2d47bee4eb4c5275ca0, type: 3}
   m_PrefabInstance: {fileID: 959574351}
-  m_PrefabAsset: {fileID: 0}
---- !u!223 &1062568351 stripped
-Canvas:
-  m_CorrespondingSourceObject: {fileID: 9204692562933795213, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-  m_PrefabInstance: {fileID: 1514700520}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1203926385
 PrefabInstance:
@@ -921,7 +973,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1514700520
+--- !u!1001 &1797151793
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -929,18 +981,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1682922545344063088, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-      propertyPath: loadCanvas
-      value: 
-      objectReference: {fileID: 1062568351}
-    - target: {fileID: 1792871598366607946, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-      propertyPath: m_RaycastTarget
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4357894077488911800, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 6644035447449605442, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -984,18 +1024,6 @@ PrefabInstance:
     - target: {fileID: 7133605627562252430, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
       propertyPath: m_Name
       value: LevelManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 7133605627562252430, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9204692562933795213, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-      propertyPath: m_PixelPerfect
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9204692562933795213, guid: 4371c58ed07f8264fb2f002288eb192e, type: 3}
-      propertyPath: m_SortingOrder
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1087,5 +1115,5 @@ SceneRoots:
   - {fileID: 1478719102}
   - {fileID: 1224454805}
   - {fileID: 627858143}
-  - {fileID: 1514700520}
-  - {fileID: 442615697}
+  - {fileID: 1797151793}
+  - {fileID: 686957628}

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,4 +1,6 @@
+using System;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
@@ -13,6 +15,14 @@ public class LevelManager : MonoBehaviour
     private Color currentLoadImageColor;
     private string targetSceneName;
     
+    public UnityEvent<string> levelChange;
+    public UnityEvent gameStart;
+
+    private void Start()
+    {
+        gameStart.Invoke();
+    }
+
     private void Awake()
     {
         if (instance == null)
@@ -24,11 +34,6 @@ public class LevelManager : MonoBehaviour
         {
             Destroy(gameObject);
         }
-    }
-
-    private void Start()
-    {
-        AudioManager.Play(MusicName.MainMenuTheme);
     }
 
     private void Update()
@@ -92,9 +97,9 @@ public class LevelManager : MonoBehaviour
             loadImage.color = currentLoadImageColor;
 
             isFadingIn = true;
+            
+            levelChange.Invoke(targetSceneName);
         }
-
-        AudioManager.StopAll();
     }
 
     public void ExitGame()

--- a/Assets/Scripts/Sound/AudioManager.cs
+++ b/Assets/Scripts/Sound/AudioManager.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
-using UnityEngine.SceneManagement;
 
 public class AudioManager : MonoBehaviour
 {
@@ -105,6 +104,22 @@ public class AudioManager : MonoBehaviour
                 StopAll();
                 Play(MusicName.Level3Theme);
                 break;
+        }
+    }
+
+    public void ChangeVolumeOfMusicOnInstance(float newVolume)
+    {
+        foreach (var music in instance.musics)
+        {
+            music.ChangeVolume(newVolume);
+        }
+    }
+    
+    public void ChangeVolumeOfSoundsOnInstance(float newVolume)
+    {
+        foreach (var sound in instance.sounds)
+        {
+            sound.ChangeVolume(newVolume);
         }
     }
     

--- a/Assets/Scripts/Sound/AudioManager.cs
+++ b/Assets/Scripts/Sound/AudioManager.cs
@@ -1,24 +1,30 @@
 using UnityEngine;
-using System;
-using UnityEngine.Audio;
 using System.Linq;
 using System.Collections.Generic;
+using UnityEngine.SceneManagement;
 
 public class AudioManager : MonoBehaviour
 {
+    public static AudioManager instance;
     public Sound[] sounds;
     public Music[] musics;
-    public static AudioManager instance;
 
     private readonly Dictionary<SoundName, Sound> _soundsMap = new();
     private readonly Dictionary<MusicName, Music> _musicMap = new();
 
+    private MusicName _currentMusic;
+    
     private void Awake()
     {
-        DontDestroyOnLoad(gameObject);
         if (instance == null)
+        {
             instance = this;
-        else throw new SoundException($"there can be only one {nameof(AudioManager)}. Delete duplicates!!");
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
     }
 
     private void Start()
@@ -58,6 +64,8 @@ public class AudioManager : MonoBehaviour
         foreach (var music in musics) 
             music.Stop();
 
+        _currentMusic = name;
+        
         _musicMap[name].Play();
     }
 
@@ -67,6 +75,39 @@ public class AudioManager : MonoBehaviour
             music.Stop();
     }
 
+    public void PlayMusicOnGameStart()
+    {
+        Play(MusicName.MainMenuTheme);
+    }
+    
+    public void ChangeMusicOnLevelChange(string sceneName)
+    {
+        switch (sceneName)
+        {
+            case "Credits":
+            case "Settings":
+            case "Main Menu": 
+                if (instance._currentMusic != MusicName.MainMenuTheme)
+                {
+                    StopAll();
+                    Play(MusicName.MainMenuTheme);
+                }
+                break;
+            case "Level 1":
+                StopAll();
+                Play(MusicName.Level1Theme);
+                break;
+            case "Level 2":
+                StopAll();
+                Play(MusicName.Level2Theme);
+                break;
+            case "Level 3":
+                StopAll();
+                Play(MusicName.Level3Theme);
+                break;
+        }
+    }
+    
     private static void Validate(Sound[] sounds)
     {
         var duplicates = sounds.GroupBy(s => s.name).Where(s => s.Count() > 1);

--- a/Assets/Scripts/Sound/SoundBase.cs
+++ b/Assets/Scripts/Sound/SoundBase.cs
@@ -17,7 +17,9 @@ public abstract class SoundBase<T> where T : Enum
         source.clip = clip;
         source.volume = volume;
     }
-
+    
     public void Play() => source.Play();
     public void Stop() => source.Stop();
+
+    public void ChangeVolume(float newVolume) => source.volume = newVolume;
 }


### PR DESCRIPTION
I have made some (what I would think are) improvements to the code of the audio manager.

The first is decoupling the Level Manager and the Audio Manager by removing the direct calls to change music, instead now the Level Manager sends out two events:
a) For when the game is first launched...
![image](https://github.com/FrozzLab/2023_11_eng_03_8week/assets/32843738/1b4f8693-1cb5-426d-8642-3b06713468f6)
...which triggers the PlayMusicOnGameStart method that simply plays the Main Menu theme:
![image](https://github.com/FrozzLab/2023_11_eng_03_8week/assets/32843738/cc45e0a7-2fb1-484c-95f1-24f7333f9d22)

b) For when a level is changed...
![image](https://github.com/FrozzLab/2023_11_eng_03_8week/assets/32843738/4b109c58-0dac-4bd4-884b-4e7ac1eeee25)
...which triggers the ChangeMusicOnLevelChange method, that changes the background music to the appropriate track. In addition, it checks for the different menu screens whether the main menu music is playing already, in which case it simply does notthing to preserve the continuity of the track:
![image](https://github.com/FrozzLab/2023_11_eng_03_8week/assets/32843738/347f82ca-2e2e-4c8c-b5a3-76cd63f8f769)

This change is meant to be an improvement over the previous handling of playing/changing background music, which was not fully functional.

Another change is the removal of the exception thrown upon encountering another audio manager, as this would lead to a bug where going from the main menu -> any other scene -> main menu would lead to an exception, seeing as the main menu had the manager within it.

On top of that, the manager has been changed into a prefab for the purposes of being able to link it to the level manager prefab in general, instead of linking it by hand in the scene.

Lastly, I have added the functionality to change music and sound volume on the fly, making it possible for players to adjust the loudness to the desired level:
![image](https://github.com/FrozzLab/2023_11_eng_03_8week/assets/32843738/9632404e-f0d2-4f38-98b5-505bf8df30a6)
![image](https://github.com/FrozzLab/2023_11_eng_03_8week/assets/32843738/e827d284-9597-495e-ab3c-8efb01cfdabf)


I believe that these changes address the problems with the current audio manager implementation and, as such, should be merged to the Dev branch.